### PR TITLE
Remove duplicate keys: CameraDeviceClient.cpp

### DIFF
--- a/services/camera/libcameraservice/api2/CameraDeviceClient.cpp
+++ b/services/camera/libcameraservice/api2/CameraDeviceClient.cpp
@@ -118,13 +118,6 @@ CameraDeviceClient::CameraDeviceClient(const sp<CameraService>& cameraService,
         mPrivilegedClient = true;
     }
 
-    char value[PROPERTY_VALUE_MAX];
-    property_get("persist.vendor.camera.privapp.list", value, "");
-    String16 packagelist(value);
-    if (packagelist.contains(clientPackageName.string())) {
-        mPrivilegedClient = true;
-    }
-
     ATRACE_CALL();
     ALOGI("CameraDeviceClient %s: Opened", cameraId.string());
 }


### PR DESCRIPTION
Removed duplicate redefinition of PROPERTY_VALUE_MAX and packagelist in CameraDeviceClient.cpp,